### PR TITLE
reformat the logs to be cleaner

### DIFF
--- a/__tests__/unit/handlerUtil.js
+++ b/__tests__/unit/handlerUtil.js
@@ -14,7 +14,8 @@ describe('test/unit/handler.js', () => {
   });
 
   it('Logs for unknown key', () => {
-    const value = Buffer.from(JSON.stringify({ value: { foo: 'bar' } }));
+    const value = Buffer.from(JSON.stringify({ message: { foo: 'bar' },
+      sendTimeStamp: new Date(), }));
     const messageSet = [{ message: { key: 'key', value } }];
     const callback = jest.fn();
     defaultHandler(messageSet, 'foo', 0, callback);
@@ -22,7 +23,8 @@ describe('test/unit/handler.js', () => {
   });
 
   it('Logs for existing key', () => {
-    const value = Buffer.from(JSON.stringify({ value: { foo: 'bar' } }));
+    const value = Buffer.from(JSON.stringify({ message: { foo: 'bar' },
+      sendTimeStamp: new Date(), }));
     const messageSet = [{ message: { key: 'info', value } }];
     const callback = jest.fn();
     defaultHandler(messageSet, 'foo', 0, callback);

--- a/__tests__/unit/handlerUtil.js
+++ b/__tests__/unit/handlerUtil.js
@@ -15,7 +15,7 @@ describe('test/unit/handler.js', () => {
 
   it('Logs for unknown key', () => {
     const value = Buffer.from(JSON.stringify({ message: { foo: 'bar' },
-      sendTimeStamp: new Date(), }));
+      messageTime: new Date(), }));
     const messageSet = [{ message: { key: 'key', value } }];
     const callback = jest.fn();
     defaultHandler(messageSet, 'foo', 0, callback);
@@ -24,7 +24,7 @@ describe('test/unit/handler.js', () => {
 
   it('Logs for existing key', () => {
     const value = Buffer.from(JSON.stringify({ message: { foo: 'bar' },
-      sendTimeStamp: new Date(), }));
+      messageTime: new Date(), }));
     const messageSet = [{ message: { key: 'info', value } }];
     const callback = jest.fn();
     defaultHandler(messageSet, 'foo', 0, callback);

--- a/src/handlerUtil.js
+++ b/src/handlerUtil.js
@@ -19,6 +19,8 @@ const loggerTypes = {
   info: logger.info.bind(logger),
   debug: logger.debug.bind(logger),
   trace: logger.trace.bind(logger),
+  verbose: logger.trace.bind(logger),
+  silly: logger.trace.bind(logger),
 };
 
 // The default handler just logs out the message

--- a/src/handlerUtil.js
+++ b/src/handlerUtil.js
@@ -30,7 +30,7 @@ const defaultHandler = (messageSet, topic, partition, callback = logger.info) =>
     const value = JSON.parse(m.message.value.toString());
     const log = {
       application: topic,
-      sendTimeStamp: value.sendTimeStamp,
+      messageTime: value.messageTime,
       message: value.message,
     };
     if (loggerTypes[key]) {

--- a/src/handlerUtil.js
+++ b/src/handlerUtil.js
@@ -28,14 +28,16 @@ const defaultHandler = (messageSet, topic, partition, callback = logger.info) =>
   messageSet.forEach((m) => {
     const key = m.message.key.toString(); // logging level
     const value = JSON.parse(m.message.value.toString());
-
-    // TODO: Discuss different cases and what should be done
+    const log = {
+      application: topic,
+      sendTimeStamp: value.sendTimeStamp,
+      message: value.message,
+    };
     if (loggerTypes[key]) {
-      loggerTypes[key]('From application: ', topic, ' Message: ', value,
-      ' Received at: ', new Date());
+      loggerTypes[key](log);
     } else {
       callback('Logging with unknown key');
-      logger.info('From application: ', topic, ' Message: ', value, 'Received at: ', new Date());
+      logger.info(log);
     }
   });
 };

--- a/src/kafkaConsumer.js
+++ b/src/kafkaConsumer.js
@@ -34,7 +34,7 @@ const initConsumer = async (errorCallback) => {
     });
 
     await consumer.init();
-    debug(`Kafka consumer ${clientId} has been started as ${consumer}`);
+    debug(`Kafka consumer ${clientId} has been started`);
 
     // Construct an object that has a list of all topics as
     // keys and accordingly you can give it a handler


### PR DESCRIPTION
Reformat the logs to be cleaner, one level of nesting. Sample Log:

For JSON shaped log message:
{"level":30,
"time":1563838236377,
"pid":84648,
"hostname":"deepanshugu-ltm.internal.salesforce.com",
"application":"foo",
"sendTimeStamp":"2019-07-22T23:30:36.376Z",
"message":{"foo":"bar"},
"v":1}

For string shaped log message:
{"level":30,
"time":1563839420830,
"pid":85552,
"hostname":"deepanshugu-ltm.internal.salesforce.com",
"application":"foo",
"sendTimeStamp":"2019-07-22T23:50:20.830Z",
"message":"string value",
"v":1}